### PR TITLE
Fix text alignment issue visible in the downloaded screenshot

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,6 +157,11 @@ export default function GitHubContribScreenshot() {
 
   async function downloadScreenshot() {
     if (!containerRef.current) return;
+    
+    const style = document.createElement('style');
+    document.head.appendChild(style);
+    style.sheet?.insertRule('body > div:last-child img { display: inline-block; }');
+    
     const canvas = await html2canvas(containerRef.current, { 
       scale: 2, 
       useCORS: true, 


### PR DESCRIPTION
This PR fixes an issue where text appeared misaligned in the downloaded screenshot, even though the UI displayed correctly within the application.

<img width="1952" height="870" alt="tcetamitpandey-github-contribs-forest" src="https://github.com/user-attachments/assets/84727281-39dd-4405-8c50-b34f082aa5d4" />
